### PR TITLE
James review - clarified instructions w UUIDs, added lab env advice

### DIFF
--- a/docs/r33-4.mdx
+++ b/docs/r33-4.mdx
@@ -114,7 +114,7 @@ report to a file named `license_report.zip`.
     ```
     </Collapsible>
 
-Note the UUID at the end of the statusLink output line. It's a string of 8-4-4-12 characters (example:7b926064-3360-4354-86d8-79b390efd178). Use this UUID string in the following commands where you see <id>.
+Note the UUID at the end of the statusLink output line. It's a string of 8-4-4-12 characters (example:7b926064-3360-4354-86d8-79b390efd178). Use this UUID string in the following commands where you see \<id\>.
 
 1. Check the status to check if the report is sucessfully uploaded and the status report is ready to download. Remember to swap out \<id\> for the UUID returned when you submitted the usage report to F5.
     ```shell
@@ -138,7 +138,7 @@ Note the UUID at the end of the statusLink output line. It's a string of 8-4-4-1
     </Collapsible>
 
 1. Run the following to download the license acknowledgment report from F5. In the example below, we are downloading the
-report to a file named `lic_acknowledgement.zip`. Remember to swap out <id> for the UUID returned when you submitted the usage report to F5.
+report to a file named `lic_acknowledgement.zip`. Remember to swap out \<id\> for the UUID returned when you submitted the usage report to F5.
 
     ```shell
     curl --location \


### PR DESCRIPTION
added info for commands where the user must grab a UUID from the report upload and provide in the subsequent commands in place of <id>